### PR TITLE
Fix highlightText regex escaping

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Event } from '../types/Event'
 import { useTimelineStore } from '../store/timelineStore'
+import { highlightText } from '../utils/highlightText'
 
 interface EventCardProps {
   event: Event
@@ -32,20 +33,6 @@ const EventCard = ({ event, index }: EventCardProps) => {
     return colors[hash % colors.length]
   }
 
-  const highlightText = (text: string, search: string) => {
-    if (!search) return text
-    
-    const regex = new RegExp(`(${search})`, 'gi')
-    const parts = text.split(regex)
-    
-    return parts.map((part, i) => 
-      regex.test(part) ? (
-        <mark key={i} className="bg-yellow-200 text-yellow-900 rounded px-1">
-          {part}
-        </mark>
-      ) : part
-    )
-  }
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString)

--- a/src/utils/highlightText.test.tsx
+++ b/src/utils/highlightText.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { highlightText } from './highlightText'
+
+describe('highlightText', () => {
+  it('escapes regex characters in search string', () => {
+    const result = highlightText('a.c', 'a.c') as (string | JSX.Element)[]
+    const mark = result.find((el) => React.isValidElement(el))
+    expect(mark).toBeTruthy()
+    expect(mark.props.children).toBe('a.c')
+  })
+  it('does not treat regex chars specially', () => {
+    const result = highlightText('abc', 'a.c') as (string | JSX.Element)[]
+    const mark = result.find((el) => React.isValidElement(el))
+    expect(mark).toBeUndefined()
+  })
+})

--- a/src/utils/highlightText.tsx
+++ b/src/utils/highlightText.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+
+export const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+export const highlightText = (text: string, search: string): ReactNode[] => {
+  if (!search) return text
+  const regex = new RegExp(`(${escapeRegExp(search)})`, 'gi')
+  const parts = text.split(regex)
+  return parts.map((part, i) =>
+    regex.test(part) ? (
+      <mark key={i} className="bg-yellow-200 text-yellow-900 rounded px-1">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  )
+}


### PR DESCRIPTION
## Summary
- avoid treating search string as regex by escaping special characters
- refactor highlightText into new util
- test highlightText behaviour with special characters

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_683f6148c20c8331b7658bfd23a3bdc5